### PR TITLE
Fix: Move hooks.py to correct location for ERPNext module import

### DIFF
--- a/farm_management/hooks.py
+++ b/farm_management/hooks.py
@@ -1,0 +1,174 @@
+from farm_management import __version__ as app_version
+
+app_name = "farm_management"
+app_title = "Farm Management"
+app_publisher = "Farm Management Solutions"
+app_description = "Comprehensive farm management system for poultry and pig farms"
+app_icon = "octicon octicon-file-directory"
+app_color = "green"
+app_email = "admin@farmmanagement.com"
+app_license = "MIT"
+
+# Includes in <head>
+# ------------------
+
+# include js, css files in header of desk.html
+# app_include_css = "/assets/farm_management/css/farm_management.css"
+# app_include_js = "/assets/farm_management/js/farm_management.js"
+
+# include js, css files in header of web template
+# web_include_css = "/assets/farm_management/css/farm_management.css"
+# web_include_js = "/assets/farm_management/js/farm_management.js"
+
+# include custom scss in every website theme (without file extension ".scss")
+# website_theme_scss = "farm_management/public/scss/website"
+
+# include js, css files in header of web form
+# webform_include_js = {"doctype": "public/js/doctype.js"}
+# webform_include_css = {"doctype": "public/css/doctype.css"}
+
+# include js in page
+# page_js = {"page" : "public/js/file.js"}
+
+# include js in doctype views
+# doctype_js = {"doctype" : "public/js/doctype.js"}
+# doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
+# doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
+# doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
+
+# Home Pages
+# ----------
+
+# application home page (will override Website Settings)
+# home_page = "login"
+
+# website user home page (by Role)
+# role_home_page = {
+#	"Role": "home_page"
+# }
+
+# Generators
+# ----------
+
+# automatically create page for each record of this doctype
+# website_generators = ["Web Page"]
+
+# Installation
+# ------------
+
+# before_install = "farm_management.install.before_install"
+# after_install = "farm_management.install.after_install"
+
+# Desk Notifications
+# ------------------
+# See frappe.core.notifications.get_notification_config
+
+# notification_config = "farm_management.notifications.get_notification_config"
+
+# Permissions
+# -----------
+# Permissions evaluated in scripted ways
+
+# permission_query_conditions = {
+# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
+# }
+#
+# has_permission = {
+# 	"Event": "frappe.desk.doctype.event.event.has_permission",
+# }
+
+# DocType Class
+# ---------------
+# Override standard doctype classes
+
+# override_doctype_class = {
+# 	"ToDo": "custom_app.overrides.CustomToDo"
+# }
+
+# Document Events
+# ---------------
+# Hook on document methods and events
+
+# doc_events = {
+# 	"*": {
+# 		"on_update": "method",
+# 		"on_cancel": "method",
+# 		"on_trash": "method"
+#	}
+# }
+
+# Scheduled Tasks
+# ---------------
+
+# scheduler_events = {
+# 	"all": [
+# 		"farm_management.tasks.all"
+# 	],
+# 	"daily": [
+# 		"farm_management.tasks.daily"
+# 	],
+# 	"hourly": [
+# 		"farm_management.tasks.hourly"
+# 	],
+# 	"weekly": [
+# 		"farm_management.tasks.weekly"
+# 	]
+# 	"monthly": [
+# 		"farm_management.tasks.monthly"
+# 	]
+# }
+
+# Testing
+# -------
+
+# before_tests = "farm_management.install.before_tests"
+
+# Overriding Methods
+# ------------------------------
+#
+# override_whitelisted_methods = {
+# 	"frappe.desk.doctype.event.event.get_events": "farm_management.event.get_events"
+# }
+#
+# each overriding function accepts a `data` argument;
+# generated from the base implementation of the doctype dashboard,
+# along with any modifications made in other Frappe apps
+# override_doctype_dashboards = {
+# 	"Task": "farm_management.task.get_dashboard_data"
+# }
+
+# exempt linked doctypes from being automatically cancelled
+#
+# auto_cancel_exempted_doctypes = ["Auto Repeat"]
+
+
+# User Data Protection
+# --------------------
+
+user_data_fields = [
+	{
+		"doctype": "{doctype_1}",
+		"filter_by": "{filter_by}",
+		"redact_fields": ["{field_1}", "{field_2}"],
+		"partial": 1,
+	},
+	{
+		"doctype": "{doctype_2}",
+		"filter_by": "{filter_by}",
+		"partial": 1,
+	},
+	{
+		"doctype": "{doctype_3}",
+		"strict": False,
+	},
+	{
+		"doctype": "{doctype_4}"
+	}
+]
+
+# Authentication and authorization
+# --------------------------------
+
+# auth_hooks = [
+# 	"farm_management.auth.validate"
+# ]


### PR DESCRIPTION
- Move hooks.py from root to farm_management/hooks.py
- Fix import statement to use absolute import
- Resolves 'No module named farm_management.hooks' error
- ERPNext expects hooks.py inside the module directory